### PR TITLE
update dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "author": "Rebecca Turner <me@re-becca.org> (http://re-becca.org)",
   "license": "ISC",
   "devDependencies": {
-    "standard": "^5.4.1",
-    "tap": "^2.3.1"
+    "standard": "^12.0.1",
+    "tap": "^12.5.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, `npm install && npm audit` will flag `standard` and `tap`.
With this update, that is no longer the case. `npm test` still passes.