### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var MurmurHash3 = require('imurmurhash')
 module.exports = function (uniq) {
   if (uniq) {
     var hash = new MurmurHash3(uniq)
-    return ('00000000' + hash.result().toString(16)).substr(-8)
+    return ('00000000' + hash.result().toString(16)).slice(-8)
   } else {
-    return (Math.random().toString(16) + '0000000').substr(2, 8)
+    return (Math.random().toString(16) + '0000000').slice(2, 10)
   }
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.