### PR TITLE
Cache `MurmurHash3` object instances where `uniq`es are keys

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,15 @@
 'use strict'
-var MurmurHash3 = require('imurmurhash')
+const MurmurHash3 = require('imurmurhash')
+
+const murmurHash3Cache = new Map()
 
 module.exports = function (uniq) {
   if (uniq) {
-    var hash = new MurmurHash3(uniq)
+    let hash = murmurHash3Cache.get(uniq)
+    if (!hash) {
+      hash = new MurmurHash3(uniq)
+      murmurHash3Cache.set(uniq, hash)
+    }
     return ('00000000' + hash.result().toString(16)).slice(-8)
   } else {
     return (Math.random().toString(16) + '0000000').slice(2, 10)


### PR DESCRIPTION
<!-- What / Why -->
I've noticed that every time `uniqueSlug` function is called with `uniq` argument always new instance of `MurmurHash3` object is created. Maybe it would be beneficial to cache them using `Map` where key is an `uniq` argument.
<!-- Describe the request in detail. What it does and why it's being changed. -->

I've compared performance of `unique-slug` with such caching and without and those are results (source code available here https://github.com/arturgawlik/unique-slug-benchmark/blob/main/index.js):
```text
┌─────────┬──────────────────────────────────────────────┬───────────────────┬──────────────────┬────────────────────────┬────────────────────────┬─────────┐
│ (index) │ Task name                                    │ Latency avg (ns)  │ Latency med (ns) │ Throughput avg (ops/s) │ Throughput med (ops/s) │ Samples │
├─────────┼──────────────────────────────────────────────┼───────────────────┼──────────────────┼────────────────────────┼────────────────────────┼─────────┤
│ 0       │ 'unique-slug'                                │ '355.27 ± 0.36%'  │ '379.00 ± 4.00'  │ '2896311 ± 0.02%'      │ '2638522 ± 27556'      │ 2814792 │
│ 1       │ "unique-slug - no 'new' every call"          │ '299.15 ± 0.33%'  │ '272.00 ± 3.00'  │ '3427100 ± 0.01%'      │ '3676471 ± 41002'      │ 3342763 │
│ 2       │ '1000000 unique-slugs'                       │ '454.33 ± 3.09%'  │ '402.00 ± 11.00' │ '2293466 ± 0.02%'      │ '2487562 ± 69983'      │ 2201052 │
│ 3       │ "1000000 unique-slugs - no 'new' every call" │ '472.72 ± 15.06%' │ '387.00 ± 11.00' │ '2441422 ± 0.02%'      │ '2583979 ± 75595'      │ 2177460 │
└─────────┴──────────────────────────────────────────────┴───────────────────┴──────────────────┴────────────────────────┴────────────────────────┴─────────┘
```
Bench results interpretation:
For calling every time with same `uniq` there is about 30% improvement in med throughput (`unique-slug` vs `unique-slug - no 'new' every call`).
For calling for 1 000 000 different `uniq`s there is no performance degradation. (`1000000 unique-slugs` vs `1000000 unique-slugs - no 'new' every time`).

If this package does not care about those type of improvements, or for some other reasons this is not beneficial at all, please feel free to just close this PR.